### PR TITLE
fix: sidebar icons shrinking when collapsing the sidebar

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -138,7 +138,7 @@ export function AppSidebar() {
 
   return (
     <Sidebar collapsible="icon" className="border-r border-sidebar-border">
-      <SidebarHeader className="p-4">
+      <SidebarHeader className="p-4 group-data-[collapsible=icon]:p-2">
         <Link to="/" className="flex items-center gap-2" title="Back to AgentSwarms home">
           <img
             src={agentSwarmsLogo}

--- a/src/components/GlobalCreateMenu.tsx
+++ b/src/components/GlobalCreateMenu.tsx
@@ -42,7 +42,11 @@ export function GlobalCreateMenu() {
           </Link>
         </DropdownMenuItem>
         <DropdownMenuItem asChild>
-          <Link to="/swarms" search={{ view: "canvas", new: 1 }} className="flex items-center gap-2 cursor-pointer">
+          <Link
+            to="/swarms"
+            search={{ view: "canvas", new: 1 }}
+            className="flex items-center gap-2 cursor-pointer"
+          >
             <Network className="h-4 w-4 text-primary" />
             <div className="flex flex-col">
               <span className="text-sm font-medium">New Swarm</span>
@@ -51,7 +55,11 @@ export function GlobalCreateMenu() {
           </Link>
         </DropdownMenuItem>
         <DropdownMenuItem asChild>
-          <Link to="/knowledge" search={{ new: 1 }} className="flex items-center gap-2 cursor-pointer">
+          <Link
+            to="/knowledge"
+            search={{ new: 1 }}
+            className="flex items-center gap-2 cursor-pointer"
+          >
             <BookOpen className="h-4 w-4 text-primary" />
             <div className="flex flex-col">
               <span className="text-sm font-medium">New Knowledge Base</span>


### PR DESCRIPTION
Resolved the issue where sidebar icons were shrinking along with the sidebar when collapsed. Icons now retain their proper size in the collapsed state.

Now, icon is proper visible.
<img width="942" height="762" alt="image" src="https://github.com/user-attachments/assets/b98eb46f-adb3-4a85-a7ff-39aa77d202e1" />
