### PR TITLE
theniteshdev/bug/approval box UI fixes

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -138,7 +138,7 @@ export function AppSidebar() {
 
   return (
     <Sidebar collapsible="icon" className="border-r border-sidebar-border">
-      <SidebarHeader className="p-4">
+      <SidebarHeader className="p-4 group-data-[collapsible=icon]:p-2">
         <Link to="/" className="flex items-center gap-2" title="Back to AgentSwarms home">
           <img
             src={agentSwarmsLogo}

--- a/src/components/ApprovalInbox.tsx
+++ b/src/components/ApprovalInbox.tsx
@@ -296,7 +296,7 @@ export function ApprovalInbox() {
                         <summary className="text-[11px] text-muted-foreground cursor-pointer hover:text-foreground select-none">
                           View payload
                         </summary>
-                        <pre className="mt-1 rounded-md bg-background border border-border/50 p-2 text-[10px] leading-relaxed overflow-x-auto font-mono text-muted-foreground">
+                        <pre className="mt-1 max-w-full rounded-md bg-background border border-border/50 p-2 text-[10px] leading-relaxed whitespace-pre-wrap break-all font-mono text-muted-foreground">
                           {JSON.stringify(ap.payload, null, 2)}
                         </pre>
                       </details>

--- a/src/components/GlobalCreateMenu.tsx
+++ b/src/components/GlobalCreateMenu.tsx
@@ -42,7 +42,11 @@ export function GlobalCreateMenu() {
           </Link>
         </DropdownMenuItem>
         <DropdownMenuItem asChild>
-          <Link to="/swarms" search={{ view: "canvas", new: 1 }} className="flex items-center gap-2 cursor-pointer">
+          <Link
+            to="/swarms"
+            search={{ view: "canvas", new: 1 }}
+            className="flex items-center gap-2 cursor-pointer"
+          >
             <Network className="h-4 w-4 text-primary" />
             <div className="flex flex-col">
               <span className="text-sm font-medium">New Swarm</span>
@@ -51,7 +55,11 @@ export function GlobalCreateMenu() {
           </Link>
         </DropdownMenuItem>
         <DropdownMenuItem asChild>
-          <Link to="/knowledge" search={{ new: 1 }} className="flex items-center gap-2 cursor-pointer">
+          <Link
+            to="/knowledge"
+            search={{ new: 1 }}
+            className="flex items-center gap-2 cursor-pointer"
+          >
             <BookOpen className="h-4 w-4 text-primary" />
             <div className="flex flex-col">
               <span className="text-sm font-medium">New Knowledge Base</span>


### PR DESCRIPTION
## Summary
- Fix a UI bug where expanding a pending approval's "View payload" details
  pane could push the Approve/Reject buttons off-screen and out of reach.

## Root cause
`ScrollArea`'s Radix viewport wraps its children in an internal
`div` styled `{ minWidth: "100%", display: "table" }` (see
`node_modules/@radix-ui/react-scroll-area`). Table-display sizing grows
to fit the *max-content* width of its children. The payload `<pre>` used
`overflow-x-auto`, which only makes the pre's own box scrollable — it
doesn't stop the browser from reporting the pre's full unwrapped-line
width as its intrinsic size to that ancestor. A payload containing one
long unbroken value (token, URL, etc.) therefore blew up the whole
scroll viewport's width, dragging the entire approval card — including
the fixed-width Approve/Reject row — off to the right, with no
horizontal scrollbar to reach it.

## Fix
`ApprovalInbox.tsx`: swap `overflow-x-auto` for
`whitespace-pre-wrap break-all max-w-full` on the payload `<pre>`, so
long values wrap inside the box instead of requesting unbounded width.
Also reads better in a narrow sheet panel than horizontal scrolling.

## Test plan
- [ ] Open the approval inbox, expand a payload containing a long
      unbroken string (e.g. a long URL/token), confirm it wraps and
      Approve/Reject stay visible and clickable.
Before:
[Screencast from 2026-07-31 20-53-27.webm](https://github.com/user-attachments/assets/0c03a078-d3bb-48c8-a2d1-4d6d5d4dff8b)

- [ ] Expand/collapse a few payloads and confirm no layout shift affects
      other cards in the list.

After: 
[Screencast from 2026-07-31 20-54-29.webm](https://github.com/user-attachments/assets/e0635295-a9ed-4e90-be1a-b36d4fec03cb)
