### PR TITLE
Add resizable, fully-collapsible sidebar with keyboard shortcut and persistence

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -14,6 +14,7 @@ import {
   SidebarMenuItem,
   SidebarHeader,
   SidebarFooter,
+  SidebarResizeHandle,
   useSidebar,
 } from "@/components/ui/sidebar";
 import { Button } from "@/components/ui/button";
@@ -62,8 +63,11 @@ export function AppSidebar() {
   );
 
   return (
-    <Sidebar collapsible="icon" className="border-r border-sidebar-border">
-      <SidebarHeader className="p-4 group-data-[collapsible=icon]:p-2">
+    // collapsible="offcanvas": the sidebar slides completely off-screen when
+    // collapsed — no icon rail remains — and the main content reclaims the
+    // freed width via the spacer div's transition-[width] to 0.
+    <Sidebar collapsible="offcanvas" className="border-r border-sidebar-border">
+      <SidebarHeader className="p-4">
         <Link to="/" className="flex items-center gap-2" title="Back to AgentSwarms home">
           <img
             src={agentSwarmsLogo}
@@ -110,6 +114,11 @@ export function AppSidebar() {
           {!collapsed && <span>Sign Out</span>}
         </Button>
       </SidebarFooter>
+
+      {/* Draggable resize handle — desktop only, hidden on mobile.
+          Lets the user drag the right edge to any width in [200, 400] px.
+          State and width are persisted to localStorage. */}
+      <SidebarResizeHandle />
     </Sidebar>
   );
 }

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -20,10 +20,46 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
-const SIDEBAR_WIDTH = "16rem";
+const SIDEBAR_LS_KEY = "sidebar_open";
+const SIDEBAR_WIDTH_LS_KEY = "sidebar_width";
 const SIDEBAR_WIDTH_MOBILE = "18rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
-const SIDEBAR_KEYBOARD_SHORTCUT = "b";
+const SIDEBAR_MIN_WIDTH = 200;
+const SIDEBAR_MAX_WIDTH = 400;
+// Default width in px (matches the old "16rem" at 16px base).
+const SIDEBAR_DEFAULT_WIDTH = 256;
+// Keyboard shortcut key (Cmd/Ctrl + this key toggles the sidebar).
+const SIDEBAR_KEYBOARD_SHORTCUT = "\\";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function readLsOpen(): boolean {
+  try {
+    const v = localStorage.getItem(SIDEBAR_LS_KEY);
+    if (v === "false") return false;
+    if (v === "true") return true;
+  } catch {
+    // localStorage unavailable (SSR / private browsing)
+  }
+  return true; // default: open
+}
+
+function readLsWidth(): number {
+  try {
+    const v = localStorage.getItem(SIDEBAR_WIDTH_LS_KEY);
+    if (v !== null) {
+      const n = Number(v);
+      if (Number.isFinite(n)) {
+        return Math.max(SIDEBAR_MIN_WIDTH, Math.min(SIDEBAR_MAX_WIDTH, n));
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return SIDEBAR_DEFAULT_WIDTH;
+}
+
+// ─── Context ──────────────────────────────────────────────────────────────────
 
 type SidebarContextProps = {
   state: "expanded" | "collapsed";
@@ -33,6 +69,8 @@ type SidebarContextProps = {
   setOpenMobile: (open: boolean) => void;
   isMobile: boolean;
   toggleSidebar: () => void;
+  sidebarWidth: number;
+  setSidebarWidth: (width: number) => void;
 };
 
 const SidebarContext = React.createContext<SidebarContextProps | null>(null);
@@ -46,6 +84,8 @@ function useSidebar() {
   return context;
 }
 
+// ─── SidebarProvider ──────────────────────────────────────────────────────────
+
 const SidebarProvider = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div"> & {
@@ -56,7 +96,7 @@ const SidebarProvider = React.forwardRef<
 >(
   (
     {
-      defaultOpen = true,
+      defaultOpen,
       open: openProp,
       onOpenChange: setOpenProp,
       className,
@@ -69,10 +109,13 @@ const SidebarProvider = React.forwardRef<
     const isMobile = useIsMobile();
     const [openMobile, setOpenMobile] = React.useState(false);
 
-    // This is the internal state of the sidebar.
-    // We use openProp and setOpenProp for control from outside the component.
-    const [_open, _setOpen] = React.useState(defaultOpen);
+    // Initialise from localStorage; fall back to prop or true.
+    const [_open, _setOpen] = React.useState<boolean>(() => {
+      if (defaultOpen !== undefined) return defaultOpen;
+      return readLsOpen();
+    });
     const open = openProp ?? _open;
+
     const setOpen = React.useCallback(
       (value: boolean | ((value: boolean) => boolean)) => {
         const openState = typeof value === "function" ? value(open) : value;
@@ -82,18 +125,32 @@ const SidebarProvider = React.forwardRef<
           _setOpen(openState);
         }
 
-        // This sets the cookie to keep the sidebar state.
+        // Persist to both cookie (legacy/SSR) and localStorage.
         document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+        try {
+          localStorage.setItem(SIDEBAR_LS_KEY, String(openState));
+        } catch {
+          // ignore
+        }
       },
       [setOpenProp, open],
     );
 
+    // Sidebar pixel width — drives the --sidebar-width CSS variable.
+    const [sidebarWidth, _setSidebarWidth] = React.useState<number>(() => readLsWidth());
+
+    const setSidebarWidth = React.useCallback((width: number) => {
+      _setSidebarWidth(width);
+      // localStorage is written by the resize handle's onPointerUp to avoid
+      // thrashing on every mousemove; nothing else needs to call this.
+    }, []);
+
     // Helper to toggle the sidebar.
     const toggleSidebar = React.useCallback(() => {
-      return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
+      return isMobile ? setOpenMobile((o) => !o) : setOpen((o) => !o);
     }, [isMobile, setOpen, setOpenMobile]);
 
-    // Adds a keyboard shortcut to toggle the sidebar.
+    // Keyboard shortcut: Cmd/Ctrl + \ toggles the sidebar.
     React.useEffect(() => {
       const handleKeyDown = (event: KeyboardEvent) => {
         if (event.key === SIDEBAR_KEYBOARD_SHORTCUT && (event.metaKey || event.ctrlKey)) {
@@ -106,8 +163,6 @@ const SidebarProvider = React.forwardRef<
       return () => window.removeEventListener("keydown", handleKeyDown);
     }, [toggleSidebar]);
 
-    // We add a state so that we can do data-state="expanded" or "collapsed".
-    // This makes it easier to style the sidebar with Tailwind classes.
     const state = open ? "expanded" : "collapsed";
 
     const contextValue = React.useMemo<SidebarContextProps>(
@@ -119,8 +174,20 @@ const SidebarProvider = React.forwardRef<
         openMobile,
         setOpenMobile,
         toggleSidebar,
+        sidebarWidth,
+        setSidebarWidth,
       }),
-      [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar],
+      [
+        state,
+        open,
+        setOpen,
+        isMobile,
+        openMobile,
+        setOpenMobile,
+        toggleSidebar,
+        sidebarWidth,
+        setSidebarWidth,
+      ],
     );
 
     return (
@@ -129,7 +196,9 @@ const SidebarProvider = React.forwardRef<
           <div
             style={
               {
-                "--sidebar-width": SIDEBAR_WIDTH,
+                // Drive width from state so the spacer div and the fixed panel
+                // both stay in sync with any user-set resize value.
+                "--sidebar-width": `${sidebarWidth}px`,
                 "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
                 ...style,
               } as React.CSSProperties
@@ -149,6 +218,8 @@ const SidebarProvider = React.forwardRef<
   },
 );
 SidebarProvider.displayName = "SidebarProvider";
+
+// ─── Sidebar ──────────────────────────────────────────────────────────────────
 
 const Sidebar = React.forwardRef<
   HTMLDivElement,
@@ -257,11 +328,13 @@ const Sidebar = React.forwardRef<
 );
 Sidebar.displayName = "Sidebar";
 
+// ─── SidebarTrigger ───────────────────────────────────────────────────────────
+
 const SidebarTrigger = React.forwardRef<
   React.ElementRef<typeof Button>,
   React.ComponentProps<typeof Button>
 >(({ className, onClick, ...props }, ref) => {
-  const { toggleSidebar } = useSidebar();
+  const { open, toggleSidebar } = useSidebar();
 
   return (
     <Button
@@ -270,6 +343,8 @@ const SidebarTrigger = React.forwardRef<
       variant="ghost"
       size="icon"
       className={cn("h-7 w-7", className)}
+      aria-expanded={open}
+      aria-label={open ? "Collapse sidebar" : "Expand sidebar"}
       onClick={(event) => {
         onClick?.(event);
         toggleSidebar();
@@ -277,11 +352,80 @@ const SidebarTrigger = React.forwardRef<
       {...props}
     >
       <PanelLeft />
-      <span className="sr-only">Toggle Sidebar</span>
+      <span className="sr-only">{open ? "Collapse sidebar" : "Expand sidebar"}</span>
     </Button>
   );
 });
 SidebarTrigger.displayName = "SidebarTrigger";
+
+// ─── SidebarResizeHandle ──────────────────────────────────────────────────────
+
+/**
+ * Draggable handle on the right edge of the sidebar. Desktop only — returns
+ * null when isMobile so the mobile Sheet is completely unaffected.
+ *
+ * Raw-ref tracking: `rawRef` stores the unbounded clientX so the clamped
+ * display value never creates a "dead zone" near the min/max boundaries.
+ * If the cursor overshoots 400 px and then comes back, the sidebar shrinks
+ * immediately — only the rendered width is clamped, not what's tracked.
+ */
+const SidebarResizeHandle = () => {
+  const { isMobile, setSidebarWidth } = useSidebar();
+  // Stores the last raw (unclamped) clientX so dragging back from a boundary
+  // feels natural — the sidebar responds as soon as the cursor reverses.
+  const rawRef = React.useRef<number | null>(null);
+
+  if (isMobile) return null;
+
+  const clamp = (v: number) => Math.max(SIDEBAR_MIN_WIDTH, Math.min(SIDEBAR_MAX_WIDTH, v));
+
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.currentTarget.setPointerCapture(e.pointerId);
+    rawRef.current = e.clientX;
+  };
+
+  const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!e.currentTarget.hasPointerCapture(e.pointerId)) return;
+    // clientX is the distance from the left of the viewport. Because the
+    // sidebar is pinned to left:0, this equals the desired sidebar width.
+    rawRef.current = e.clientX;
+    setSidebarWidth(clamp(e.clientX));
+  };
+
+  const onPointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.currentTarget.releasePointerCapture(e.pointerId);
+    if (rawRef.current !== null) {
+      const clamped = clamp(rawRef.current);
+      setSidebarWidth(clamped);
+      try {
+        localStorage.setItem(SIDEBAR_WIDTH_LS_KEY, String(clamped));
+      } catch {
+        // ignore
+      }
+    }
+    rawRef.current = null;
+  };
+
+  return (
+    <div
+      data-sidebar="resize-handle"
+      aria-hidden="true"
+      // Positioned on the fixed inner panel's right edge.
+      // z-20 sits above the sidebar content (z-10) but below modal overlays.
+      className={cn(
+        "absolute right-0 top-0 z-20 hidden h-full w-1 cursor-col-resize select-none md:block",
+        "hover:bg-sidebar-border/60 active:bg-sidebar-primary/30 transition-colors duration-100",
+      )}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+    />
+  );
+};
+SidebarResizeHandle.displayName = "SidebarResizeHandle";
+
+// ─── SidebarRail ──────────────────────────────────────────────────────────────
 
 const SidebarRail = React.forwardRef<HTMLButtonElement, React.ComponentProps<"button">>(
   ({ className, ...props }, ref) => {
@@ -311,6 +455,8 @@ const SidebarRail = React.forwardRef<HTMLButtonElement, React.ComponentProps<"bu
 );
 SidebarRail.displayName = "SidebarRail";
 
+// ─── SidebarInset ─────────────────────────────────────────────────────────────
+
 const SidebarInset = React.forwardRef<HTMLDivElement, React.ComponentProps<"main">>(
   ({ className, ...props }, ref) => {
     return (
@@ -327,6 +473,8 @@ const SidebarInset = React.forwardRef<HTMLDivElement, React.ComponentProps<"main
   },
 );
 SidebarInset.displayName = "SidebarInset";
+
+// ─── SidebarInput ─────────────────────────────────────────────────────────────
 
 const SidebarInput = React.forwardRef<
   React.ElementRef<typeof Input>,
@@ -346,6 +494,8 @@ const SidebarInput = React.forwardRef<
 });
 SidebarInput.displayName = "SidebarInput";
 
+// ─── SidebarHeader ────────────────────────────────────────────────────────────
+
 const SidebarHeader = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(
   ({ className, ...props }, ref) => {
     return (
@@ -359,6 +509,8 @@ const SidebarHeader = React.forwardRef<HTMLDivElement, React.ComponentProps<"div
   },
 );
 SidebarHeader.displayName = "SidebarHeader";
+
+// ─── SidebarFooter ────────────────────────────────────────────────────────────
 
 const SidebarFooter = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(
   ({ className, ...props }, ref) => {
@@ -374,6 +526,8 @@ const SidebarFooter = React.forwardRef<HTMLDivElement, React.ComponentProps<"div
 );
 SidebarFooter.displayName = "SidebarFooter";
 
+// ─── SidebarSeparator ─────────────────────────────────────────────────────────
+
 const SidebarSeparator = React.forwardRef<
   React.ElementRef<typeof Separator>,
   React.ComponentProps<typeof Separator>
@@ -388,6 +542,8 @@ const SidebarSeparator = React.forwardRef<
   );
 });
 SidebarSeparator.displayName = "SidebarSeparator";
+
+// ─── SidebarContent ───────────────────────────────────────────────────────────
 
 const SidebarContent = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(
   ({ className, ...props }, ref) => {
@@ -408,6 +564,8 @@ const SidebarContent = React.forwardRef<HTMLDivElement, React.ComponentProps<"di
 );
 SidebarContent.displayName = "SidebarContent";
 
+// ─── SidebarGroup ─────────────────────────────────────────────────────────────
+
 const SidebarGroup = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(
   ({ className, ...props }, ref) => {
     return (
@@ -421,6 +579,8 @@ const SidebarGroup = React.forwardRef<HTMLDivElement, React.ComponentProps<"div"
   },
 );
 SidebarGroup.displayName = "SidebarGroup";
+
+// ─── SidebarGroupLabel ────────────────────────────────────────────────────────
 
 const SidebarGroupLabel = React.forwardRef<
   HTMLDivElement,
@@ -442,6 +602,8 @@ const SidebarGroupLabel = React.forwardRef<
   );
 });
 SidebarGroupLabel.displayName = "SidebarGroupLabel";
+
+// ─── SidebarGroupAction ───────────────────────────────────────────────────────
 
 const SidebarGroupAction = React.forwardRef<
   HTMLButtonElement,
@@ -466,6 +628,8 @@ const SidebarGroupAction = React.forwardRef<
 });
 SidebarGroupAction.displayName = "SidebarGroupAction";
 
+// ─── SidebarGroupContent ──────────────────────────────────────────────────────
+
 const SidebarGroupContent = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(
   ({ className, ...props }, ref) => (
     <div
@@ -477,6 +641,8 @@ const SidebarGroupContent = React.forwardRef<HTMLDivElement, React.ComponentProp
   ),
 );
 SidebarGroupContent.displayName = "SidebarGroupContent";
+
+// ─── SidebarMenu ──────────────────────────────────────────────────────────────
 
 const SidebarMenu = React.forwardRef<HTMLUListElement, React.ComponentProps<"ul">>(
   ({ className, ...props }, ref) => (
@@ -490,6 +656,8 @@ const SidebarMenu = React.forwardRef<HTMLUListElement, React.ComponentProps<"ul"
 );
 SidebarMenu.displayName = "SidebarMenu";
 
+// ─── SidebarMenuItem ──────────────────────────────────────────────────────────
+
 const SidebarMenuItem = React.forwardRef<HTMLLIElement, React.ComponentProps<"li">>(
   ({ className, ...props }, ref) => (
     <li
@@ -501,6 +669,8 @@ const SidebarMenuItem = React.forwardRef<HTMLLIElement, React.ComponentProps<"li
   ),
 );
 SidebarMenuItem.displayName = "SidebarMenuItem";
+
+// ─── SidebarMenuButton ────────────────────────────────────────────────────────
 
 const sidebarMenuButtonVariants = cva(
   "peer/menu-button relative flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding,background-color] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 before:absolute before:left-0 before:top-1/2 before:h-4 before:w-[3px] before:-translate-y-1/2 before:rounded-full before:bg-primary before:opacity-0 before:transition-opacity data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[active=true]:before:opacity-100 data-[active=true]:[&>svg]:text-primary data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
@@ -583,6 +753,8 @@ const SidebarMenuButton = React.forwardRef<
 );
 SidebarMenuButton.displayName = "SidebarMenuButton";
 
+// ─── SidebarMenuAction ────────────────────────────────────────────────────────
+
 const SidebarMenuAction = React.forwardRef<
   HTMLButtonElement,
   React.ComponentProps<"button"> & {
@@ -614,6 +786,8 @@ const SidebarMenuAction = React.forwardRef<
 });
 SidebarMenuAction.displayName = "SidebarMenuAction";
 
+// ─── SidebarMenuBadge ─────────────────────────────────────────────────────────
+
 const SidebarMenuBadge = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(
   ({ className, ...props }, ref) => (
     <div
@@ -633,6 +807,8 @@ const SidebarMenuBadge = React.forwardRef<HTMLDivElement, React.ComponentProps<"
   ),
 );
 SidebarMenuBadge.displayName = "SidebarMenuBadge";
+
+// ─── SidebarMenuSkeleton ──────────────────────────────────────────────────────
 
 const SidebarMenuSkeleton = React.forwardRef<
   HTMLDivElement,
@@ -667,6 +843,8 @@ const SidebarMenuSkeleton = React.forwardRef<
 });
 SidebarMenuSkeleton.displayName = "SidebarMenuSkeleton";
 
+// ─── SidebarMenuSub ───────────────────────────────────────────────────────────
+
 const SidebarMenuSub = React.forwardRef<HTMLUListElement, React.ComponentProps<"ul">>(
   ({ className, ...props }, ref) => (
     <ul
@@ -683,10 +861,14 @@ const SidebarMenuSub = React.forwardRef<HTMLUListElement, React.ComponentProps<"
 );
 SidebarMenuSub.displayName = "SidebarMenuSub";
 
+// ─── SidebarMenuSubItem ───────────────────────────────────────────────────────
+
 const SidebarMenuSubItem = React.forwardRef<HTMLLIElement, React.ComponentProps<"li">>(
   ({ ...props }, ref) => <li ref={ref} {...props} />,
 );
 SidebarMenuSubItem.displayName = "SidebarMenuSubItem";
+
+// ─── SidebarMenuSubButton ─────────────────────────────────────────────────────
 
 const SidebarMenuSubButton = React.forwardRef<
   HTMLAnchorElement,
@@ -718,6 +900,8 @@ const SidebarMenuSubButton = React.forwardRef<
 });
 SidebarMenuSubButton.displayName = "SidebarMenuSubButton";
 
+// ─── Exports ──────────────────────────────────────────────────────────────────
+
 export {
   Sidebar,
   SidebarContent,
@@ -740,6 +924,7 @@ export {
   SidebarMenuSubItem,
   SidebarProvider,
   SidebarRail,
+  SidebarResizeHandle,
   SidebarSeparator,
   SidebarTrigger,
   useSidebar,


### PR DESCRIPTION
## What changed
- Sidebar can now be resized by dragging a handle on its right edge, clamped between 200–400px.
- Collapsing the sidebar (via toggle or keyboard shortcut) now fully hides it off-screen, instead of leaving a collapsed icon rail.
- Added Cmd/Ctrl+\ keyboard shortcut to toggle the sidebar open/closed.
- Sidebar width and collapsed/open state now persist across page reloads via localStorage.
- Toggle button includes aria-expanded and aria-label for accessibility.
- Mobile behavior (drawer/sheet) is unaffected by these changes.

## Why
Addresses #49  — the fixed-width sidebar was limiting space for main content, especially on smaller desktop screens. This lets users reclaim that space by resizing or fully collapsing the sidebar to fit their workflow.

## How I tested
- Dragged the resize handle in both directions — confirmed it clamps at 200px and 400px.
- Collapsed via the toggle button and Cmd/Ctrl+\ — sidebar fully disappears, main content expands to fill the freed width.
- Reloaded the page after resizing/collapsing — width and state persisted correctly.
- Checked mobile viewport — sidebar still opens as the existing drawer, unaffected.

Closes #49 