### PR TITLE
theniteshdev/feature/session restore

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -10,6 +10,8 @@ import { GlobalCreateMenu } from "@/components/GlobalCreateMenu";
 import { CommandPalette, useCommandPalette } from "@/components/CommandPalette";
 import { Search } from "lucide-react";
 import { Outlet } from "@tanstack/react-router";
+import { useSessionRestore } from "@/hooks/use-session-restore";
+import { SessionRestoreBanner } from "@/components/SessionRestoreBanner";
 
 export function AppLayout() {
   // Route-change motion is the router's defaultViewTransition (see
@@ -18,11 +20,19 @@ export function AppLayout() {
   const palette = useCommandPalette();
   const isMac =
     typeof navigator !== "undefined" && /Mac|iP(hone|ad|od)/.test(navigator.platform || "");
+  const { orphanedSession, restore, startFresh } = useSessionRestore();
   return (
     <SidebarProvider>
       <div className="flex min-h-screen w-full">
         <AppSidebar />
         <div className="flex flex-1 flex-col min-w-0">
+          {orphanedSession && (
+            <SessionRestoreBanner
+              session={orphanedSession}
+              onRestore={restore}
+              onStartFresh={startFresh}
+            />
+          )}
           {/* Sticky: on window-scrolling pages (dashboard, lists) the create/
               approvals/alerts controls otherwise leave the screen one scroll
               in. Canvas-style routes pin their own height and never scroll

--- a/src/components/SessionRestoreBanner.tsx
+++ b/src/components/SessionRestoreBanner.tsx
@@ -1,0 +1,62 @@
+import { History, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { OrphanedSession } from "@/hooks/use-session-restore";
+
+function timeAgo(savedAt: number): string {
+  const minutes = Math.max(1, Math.round((Date.now() - savedAt) / 60000));
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.round(hours / 24)}d ago`;
+}
+
+/**
+ * Prominent but non-blocking: a banner above the app header, not a modal —
+ * it never stops the user from just using the app on whatever page they
+ * landed on, and stays up (it isn't a self-dismissing toast) until they
+ * make a choice.
+ */
+export function SessionRestoreBanner({
+  session,
+  onRestore,
+  onStartFresh,
+}: {
+  session: OrphanedSession;
+  onRestore: () => void;
+  onStartFresh: () => void;
+}) {
+  return (
+    <div
+      role="status"
+      className="flex flex-wrap items-center justify-between gap-3 border-b border-primary/25 bg-primary/10 px-4 py-2.5 text-sm text-foreground"
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        <History className="h-4 w-4 shrink-0 text-primary" />
+        <p className="min-w-0 truncate">
+          We found an unsaved session from your last visit.{" "}
+          <span className="text-muted-foreground">
+            You were on <span className="font-medium text-foreground">{session.label}</span>,{" "}
+            {timeAgo(session.savedAt)}.
+          </span>
+        </p>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <Button size="sm" className="h-7 px-3 text-xs" onClick={onRestore}>
+          Restore Session
+        </Button>
+        <Button size="sm" variant="ghost" className="h-7 px-3 text-xs" onClick={onStartFresh}>
+          Start Fresh
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-7 w-7 p-0"
+          aria-label="Dismiss"
+          onClick={onStartFresh}
+        >
+          <X className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/use-session-restore.ts
+++ b/src/hooks/use-session-restore.ts
@@ -1,0 +1,185 @@
+// Route-level session restoration: if a tab gets closed/crashed while the
+// user was deep in some page (Swarm Canvas, Agent Chat, a notebook...), the
+// next time the app loads we offer to jump straight back to it instead of
+// silently landing on the dashboard.
+//
+// Scope, deliberately: this tracks *which page the user was on*, not a full
+// serialization of that page's internal state (canvas nodes, chat drafts,
+// etc). Restoring means "take me back to that URL" — every page here already
+// owns its own persistence for anything more specific (e.g. the Swarm Canvas
+// autosaves to Supabase; AgentForm has its own sessionStorage draft). This
+// hook is the thing that gets the user back to the right page to find it.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useLocation } from "@tanstack/react-router";
+import { NAV_GROUPS } from "@/lib/appNav";
+
+const SESSION_STORAGE_KEY = "agentswarms:lastSession";
+// Bump this whenever the payload shape changes. A stored payload with a
+// stale version is treated exactly like a corrupted one — discarded
+// wholesale, never partially trusted (see readStoredSession).
+const SESSION_SCHEMA_VERSION = 1;
+const SESSION_EXPIRY_MS = 24 * 60 * 60 * 1000; // 24h
+const AUTOSAVE_DEBOUNCE_MS = 800;
+
+// Never worth restoring to. This hook is mounted inside the authenticated
+// app shell (see AppLayout.tsx) so in practice `href` is always one of
+// these anyway — this is a second, cheap line of defense against ever
+// recommending a login/redirect loop if that ever changes.
+const EXCLUDED_PATH_PREFIXES = ["/login", "/docs", "/about", "/contact", "/privacy", "/terms"];
+
+type SessionPayload = {
+  version: number;
+  href: string;
+  savedAt: number;
+};
+
+export type OrphanedSession = {
+  href: string;
+  /** Human-readable page name for the banner, e.g. "Agent Swarms". */
+  label: string;
+  savedAt: number;
+};
+
+function isExcluded(href: string): boolean {
+  return EXCLUDED_PATH_PREFIXES.some(
+    (p) => href === p || href.startsWith(`${p}/`) || href.startsWith(`${p}?`),
+  );
+}
+
+// Looks the saved path up in the same nav map the sidebar and command
+// palette use, so this never has its own, second opinion about what a page
+// is called.
+function labelFor(href: string): string {
+  const pathname = href.split("?")[0].split("#")[0];
+  for (const group of NAV_GROUPS) {
+    const match = group.items.find(
+      (item) => pathname === item.url || pathname.startsWith(`${item.url}/`),
+    );
+    if (match) return match.title;
+  }
+  return pathname;
+}
+
+/**
+ * Reads, validates, and — if invalid for any reason — purges the stored
+ * session. Every failure mode (corrupted JSON, wrong schema version,
+ * expired, storage disabled) collapses to the same "nothing to restore"
+ * result rather than trying to partially recover a payload that might not
+ * mean what its shape suggests.
+ */
+function readStoredSession(): SessionPayload | null {
+  let raw: string | null;
+  try {
+    raw = window.localStorage.getItem(SESSION_STORAGE_KEY);
+  } catch {
+    return null; // storage disabled (private mode, policy) — nothing to do
+  }
+  if (!raw) return null;
+
+  let parsed: Partial<SessionPayload>;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Corrupted value — clear it so it doesn't keep failing to parse on
+    // every future load.
+    purgeStoredSession();
+    return null;
+  }
+
+  const isWellFormed =
+    parsed.version === SESSION_SCHEMA_VERSION &&
+    typeof parsed.href === "string" &&
+    typeof parsed.savedAt === "number";
+  if (!isWellFormed) {
+    // Either a genuinely malformed object, or a payload written by an
+    // older/newer app version whose shape this version doesn't promise to
+    // understand. Same handling either way: discard, don't guess.
+    purgeStoredSession();
+    return null;
+  }
+
+  const session = parsed as SessionPayload;
+  if (Date.now() - session.savedAt > SESSION_EXPIRY_MS) {
+    purgeStoredSession();
+    return null;
+  }
+  return session;
+}
+
+function writeStoredSession(href: string) {
+  try {
+    const payload: SessionPayload = { version: SESSION_SCHEMA_VERSION, href, savedAt: Date.now() };
+    window.localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    // Storage full/disabled — autosave silently no-ops, same as every other
+    // localStorage write in this app.
+  }
+}
+
+function purgeStoredSession() {
+  try {
+    window.localStorage.removeItem(SESSION_STORAGE_KEY);
+  } catch {
+    // Ignore — there's nothing left to clean up either way.
+  }
+}
+
+export function useSessionRestore() {
+  const location = useLocation();
+  const [orphaned, setOrphaned] = useState<OrphanedSession | null>(null);
+  // Flips true after the one-time "is there a leftover session" check.
+  // Belt-and-braces guard on the autosave effect below so a stored session
+  // can never be overwritten before it's had a chance to be read — see that
+  // effect's comment for why the debounce alone already makes this safe in
+  // practice.
+  const hasCheckedRef = useRef(false);
+
+  // One-time detection, on mount. Deliberately an effect and not something
+  // read during the initial render: this app is server-rendered, and the
+  // server has no `window` — reading localStorage synchronously during
+  // render would make the first client render (which might find a session)
+  // disagree with the no-`window` server render, which React reports as a
+  // hydration error. Same pattern as the sidebar's width/collapsed-state
+  // restore and the schema-health dismissal flag elsewhere in this app.
+  useEffect(() => {
+    const stored = readStoredSession();
+    if (stored && stored.href !== location.href && !isExcluded(stored.href)) {
+      setOrphaned({ href: stored.href, label: labelFor(stored.href), savedAt: stored.savedAt });
+    }
+    hasCheckedRef.current = true;
+    // Intentionally runs only once. `location.href` is read for the initial
+    // "don't restore to where I already am" comparison, not tracked — the
+    // effect below owns responding to navigation.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Debounced autosave: records the current page so the *next* app load has
+  // something fresh to offer. Paused while `orphaned` is set — until the
+  // user restores or dismisses, a reload mid-decision must not silently
+  // overwrite the very session being offered back to them.
+  useEffect(() => {
+    if (!hasCheckedRef.current || orphaned) return;
+    if (isExcluded(location.href)) return;
+
+    const timer = window.setTimeout(() => writeStoredSession(location.href), AUTOSAVE_DEBOUNCE_MS);
+    return () => window.clearTimeout(timer);
+  }, [location.href, orphaned]);
+
+  const restore = useCallback(() => {
+    if (!orphaned) return;
+    // A hard navigation, not the router's client-side `navigate()`: the
+    // restored href is an arbitrary runtime string — whatever page the user
+    // happened to be on — not one of the router's statically-typed route
+    // literals, and a full reload is a trivial cost for a once-per-crash
+    // recovery action.
+    window.location.href = orphaned.href;
+  }, [orphaned]);
+
+  const startFresh = useCallback(() => {
+    purgeStoredSession();
+    setOrphaned(null);
+  }, []);
+
+  return { orphanedSession: orphaned, restore, startFresh };
+}


### PR DESCRIPTION
## Summary

Adds route-level session restoration: if a tab closes or crashes mid-work (deep in the Swarm Canvas, an Agent Chat conversation, a notebook...), the app currently just lands back on the dashboard next time with no way back. This detects that and offers to jump straight back to the page the user was on.

**Scope note**: this tracks *which page* the user was on, not a full serialization of that page's internal state (canvas nodes, chat drafts, etc.). Restoring means "take me back to that URL" — pages that need more than that already own their own persistence (the Swarm Canvas autosaves to Supabase; the Create Agent form has its own `sessionStorage` draft). This is the thing that gets the user back to the right page to find it, not a replacement for either.

## Commits

- **`aa8872c`** — `useSessionRestore`: debounced autosave of the current `href` (paused while a restore decision is pending), mount-only detection to avoid a hydration mismatch, and expiry/corruption/schema-mismatch handling that all collapse to the same "nothing to restore, purge it" outcome.
- **`5e8d2a7`** — `SessionRestoreBanner`: the presentational UI — diagnostic text, which page and how long ago, Restore/Start Fresh actions.
- **`c6a21ac`** — wired into `AppLayout` (the authenticated shell), not the true app root — restoring to a login/marketing/docs page is never meaningful.

## Design decisions worth flagging

- **Restore is a hard navigation** (`window.location.href = ...`), not the router's client-side `navigate()`. The restored href is an arbitrary runtime string — whatever page the user happened to be on — not one of the router's statically-typed route literals, and a full reload is a trivial cost for a once-per-crash recovery action.
- **The banner is not `position: sticky`.** It sits in normal flow above the app's own sticky header. Two independent sticky elements at `top-0` don't coordinate their heights automatically and would overlap once scrolled; since this only ever needs to be visible once, at the top, right after load, a normal block avoids that entirely.
- **Never offers to restore to the current page** — if the stored href matches where the user already is, there's nothing to prompt.
- **Autosave pauses while a decision is pending.** Otherwise a reload mid-decision (before clicking either button) would silently overwrite the very session being offered back to the user.

## Edge cases handled (and verified, not just written)

I tested every one of these against a running instance via two temporary probe routes (deleted before committing) rather than trusting the logic on inspection alone:

| Case | Behavior |
|---|---|
| Corrupted JSON in storage | Discarded, storage purged, no crash |
| Unrecognized schema `version` (app updated) | Discarded, storage purged |
| Entry older than 24h | Discarded, storage purged |
| Stored href equals current href | No banner |
| Restore clicked | Hard-navigates to the stored href |
| Start Fresh / dismiss clicked | Storage cleared, banner gone |
| Normal cross-page case | Banner shows the correct page label and relative time |

All seven produced zero console errors, including no hydration warnings.

## Test plan

- [ ] Open the app, navigate into a real page (e.g. Agent Builder), wait ~1s, close the tab.
- [ ] Reopen the app — confirm the banner shows the correct page name.
- [ ] Click "Restore Session" — confirm it lands back on that exact page.
- [ ] Repeat, click "Start Fresh" instead — confirm the banner doesn't reappear on the next load.
- [ ] Manually edit `localStorage["agentswarms:lastSession"]` to a >24h-old timestamp, reload — confirm no banner and the key gets cleaned up.
- [ ] Manually corrupt the same key's value, reload — confirm no crash and no banner.
<img width="1680" height="196" alt="image" src="https://github.com/user-attachments/assets/ec548e93-d5ec-46c1-908c-fce466f4e0b5" />
